### PR TITLE
Added react 18 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "@storybook/components": "^6.4.0",
     "@storybook/core-events": "^6.4.0",
     "@storybook/theming": "^6.4.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
Upgrading the project to React 18 forces you to use the --force or --legacy-peer-deps flag.
This change fixes dependency issues in React 18.

<img width="908" alt="react-18-issue" src="https://user-images.githubusercontent.com/26112509/171005276-e5d421e8-dd82-471c-be95-77dac0ffdbd5.png">